### PR TITLE
refactor: switch to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "webdriver"
   ],
   "license": "MIT",
+  "type": "module",
   "main": "dist/server.js",
   "browser": "dist/client.js",
   "types": "src/server/index.ts",
@@ -20,8 +21,8 @@
   "scripts": {
     "build": "NODE_OPTIONS=--max_old_space_size=6144 rollup -c",
     "test": "npm run test:odc && npm run test:cdp",
-    "test:odc": "MODE=ODC mocha -r tsx/cjs -b -t 5000 test/**/*.ts",
-    "test:cdp": "MODE=CDP mocha -r tsx/cjs -b -t 5000 test/**/*.ts"
+    "test:odc": "MODE=ODC mocha -r tsx -b -t 5000 test/**/*.ts",
+    "test:cdp": "MODE=CDP mocha -r tsx -b -t 5000 test/**/*.ts"
   },
   "engines": {
     "node": ">=18"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,7 +12,7 @@ export default [
     output: [
       {
         file: pkg.main,
-        format: 'cjs',
+        format: 'es',
         exports: 'named',
         sourcemap: true,
       },

--- a/src/client/commands/active.ts
+++ b/src/client/commands/active.ts
@@ -1,6 +1,6 @@
 import type { Element } from '@appium/types';
-import { NoSuchElement } from '../errors/NoSuchElement';
-import { toWebDriverElement } from '../helpers/Element';
+import { NoSuchElement } from '../errors/NoSuchElement.js';
+import { toWebDriverElement } from '../helpers/Element.js';
 
 export function active(): Element {
   const element = window.document.activeElement;

--- a/src/client/commands/clear.ts
+++ b/src/client/commands/clear.ts
@@ -1,6 +1,6 @@
-import { InvalidElementState } from '../errors/InvalidElementState';
-import { fromWebDriverElement } from '../helpers/Element';
-import { isEditableElement } from '../helpers/isEditableElement';
+import { InvalidElementState } from '../errors/InvalidElementState.js';
+import { fromWebDriverElement } from '../helpers/Element.js';
+import { isEditableElement } from '../helpers/isEditableElement.js';
 
 export function clear(elementId: string): void {
   const element = fromWebDriverElement(elementId);

--- a/src/client/commands/click.ts
+++ b/src/client/commands/click.ts
@@ -1,7 +1,7 @@
 import scrollIntoView from 'scroll-into-view-if-needed';
-import { ElementNotInteractable } from '../errors/ElementNotInteractable';
-import { fromWebDriverElement } from '../helpers/Element';
-import { isPointerInteractable } from '../helpers/isPointerInteractable';
+import { ElementNotInteractable } from '../errors/ElementNotInteractable.js';
+import { fromWebDriverElement } from '../helpers/Element.js';
+import { isPointerInteractable } from '../helpers/isPointerInteractable.js';
 
 export function click(elementId: string): void {
   const element = fromWebDriverElement(elementId);

--- a/src/client/commands/command.ts
+++ b/src/client/commands/command.ts
@@ -1,4 +1,4 @@
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export async function command({ expression, args, options }: { expression: string; args: any[]; options: any }, callback: (result: any) => any) {
   try {

--- a/src/client/commands/createNewWindow.ts
+++ b/src/client/commands/createNewWindow.ts
@@ -1,6 +1,6 @@
 import type { NewWindow } from '@appium/types';
 import { v4 as uuid } from 'uuid';
-import { InvalidArgument } from '../errors/InvalidArgument';
+import { InvalidArgument } from '../errors/InvalidArgument.js';
 
 export function createNewWindow(this: { url?: string }, type: string): NewWindow {
   const handle = uuid();

--- a/src/client/commands/deleteCookie.ts
+++ b/src/client/commands/deleteCookie.ts
@@ -1,4 +1,4 @@
-import { setCookie } from './setCookie';
+import { setCookie } from './setCookie.js';
 
 export function deleteCookie(name: string): void {
   setCookie({ name, value: '', expiry: 0 });

--- a/src/client/commands/deleteCookies.ts
+++ b/src/client/commands/deleteCookies.ts
@@ -1,5 +1,5 @@
-import { deleteCookie } from './deleteCookie';
-import { getCookies } from './getCookies';
+import { deleteCookie } from './deleteCookie.js';
+import { getCookies } from './getCookies.js';
 
 export function deleteCookies(): void {
   getCookies().forEach(({ name }) => deleteCookie(name));

--- a/src/client/commands/elementDisplayed.ts
+++ b/src/client/commands/elementDisplayed.ts
@@ -1,5 +1,5 @@
-import { fromWebDriverElement } from '../helpers/Element';
-import { getElementRect } from './getElementRect';
+import { fromWebDriverElement } from '../helpers/Element.js';
+import { getElementRect } from './getElementRect.js';
 
 export function elementDisplayed(elementId: string): boolean {
   const element = fromWebDriverElement(elementId);

--- a/src/client/commands/elementEnabled.ts
+++ b/src/client/commands/elementEnabled.ts
@@ -1,4 +1,4 @@
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function elementEnabled(elementId: string): boolean {
   const element = fromWebDriverElement(elementId);

--- a/src/client/commands/elementSelected.ts
+++ b/src/client/commands/elementSelected.ts
@@ -1,4 +1,4 @@
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function elementSelected(elementId: string): boolean {
   const element = fromWebDriverElement(elementId);

--- a/src/client/commands/execute.ts
+++ b/src/client/commands/execute.ts
@@ -1,6 +1,6 @@
 import { cloneDeepWith, has, isElement } from 'lodash-es';
-import { JavaScriptError } from '../errors/JavaScriptError';
-import { fromWebDriverElement, toWebDriverElement, WEB_ELEMENT_IDENTIFIER } from '../helpers/Element';
+import { JavaScriptError } from '../errors/JavaScriptError.js';
+import { fromWebDriverElement, toWebDriverElement, WEB_ELEMENT_IDENTIFIER } from '../helpers/Element.js';
 
 export function execute(script: string, args: unknown[]): unknown {
   const normalizedArgs = cloneDeepWith(args, (value) => {

--- a/src/client/commands/executeAsync.ts
+++ b/src/client/commands/executeAsync.ts
@@ -1,6 +1,6 @@
 import { cloneDeepWith, has, isElement } from 'lodash-es';
-import { JavaScriptError } from '../errors/JavaScriptError';
-import { fromWebDriverElement, toWebDriverElement, WEB_ELEMENT_IDENTIFIER } from '../helpers/Element';
+import { JavaScriptError } from '../errors/JavaScriptError.js';
+import { fromWebDriverElement, toWebDriverElement, WEB_ELEMENT_IDENTIFIER } from '../helpers/Element.js';
 
 export async function executeAsync(script: string, args: unknown[]): Promise<unknown> {
   const normalizedArgs = cloneDeepWith(args, (value) => {

--- a/src/client/commands/findElOrEls.ts
+++ b/src/client/commands/findElOrEls.ts
@@ -1,7 +1,7 @@
 import type { Element as WebDriverElement } from '@appium/types';
-import { toWebDriverElement } from '../helpers/Element';
-import { getElement } from '../helpers/getElement';
-import { getElements } from '../helpers/getElements';
+import { toWebDriverElement } from '../helpers/Element.js';
+import { getElement } from '../helpers/getElement.js';
+import { getElements } from '../helpers/getElements.js';
 
 export function findElOrEls(strategy: string, selector: string, mult: boolean, context: string): WebDriverElement | WebDriverElement[] {
   if (mult) {

--- a/src/client/commands/getAttribute.ts
+++ b/src/client/commands/getAttribute.ts
@@ -1,4 +1,4 @@
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function getAttribute(name: string, elementId: string): string | null {
   return fromWebDriverElement(elementId).getAttribute(name);

--- a/src/client/commands/getCookie.ts
+++ b/src/client/commands/getCookie.ts
@@ -1,6 +1,6 @@
 import type { Cookie } from '@appium/types';
-import { NoSuchCookie } from '../errors/NoSuchCookie';
-import { getCookies } from './getCookies';
+import { NoSuchCookie } from '../errors/NoSuchCookie.js';
+import { getCookies } from './getCookies.js';
 
 export function getCookie(name: string): Cookie {
   const cookies = getCookies();

--- a/src/client/commands/getCssProperty.ts
+++ b/src/client/commands/getCssProperty.ts
@@ -1,4 +1,4 @@
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function getCssProperty(name: string, elementId: string): string {
   const element = fromWebDriverElement(elementId);

--- a/src/client/commands/getElementRect.ts
+++ b/src/client/commands/getElementRect.ts
@@ -1,5 +1,5 @@
 import type { Rect } from '@appium/types';
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function getElementRect(elementId: string): Rect {
   const element = fromWebDriverElement(elementId);

--- a/src/client/commands/getName.ts
+++ b/src/client/commands/getName.ts
@@ -1,4 +1,4 @@
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function getName(elementId: string): string {
   return fromWebDriverElement(elementId).tagName.toLowerCase();

--- a/src/client/commands/getProperty.ts
+++ b/src/client/commands/getProperty.ts
@@ -1,4 +1,4 @@
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function getProperty(name: string, elementId: string): string | null {
   const element = fromWebDriverElement(elementId);

--- a/src/client/commands/getText.ts
+++ b/src/client/commands/getText.ts
@@ -1,4 +1,4 @@
-import { fromWebDriverElement } from '../helpers/Element';
+import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function getText(elementId: string): string {
   return fromWebDriverElement(elementId).innerText;

--- a/src/client/commands/maximizeWindow.ts
+++ b/src/client/commands/maximizeWindow.ts
@@ -1,5 +1,5 @@
 import type { Rect } from '@appium/types';
-import { setWindowRect } from './setWindowRect';
+import { setWindowRect } from './setWindowRect.js';
 
 export function maximizeWindow(): Rect {
   const width = window.screen.availWidth;

--- a/src/client/commands/setCookie.ts
+++ b/src/client/commands/setCookie.ts
@@ -1,5 +1,5 @@
 import type { Cookie } from '@appium/types';
-import { InvalidArgument } from '../errors/InvalidArgument';
+import { InvalidArgument } from '../errors/InvalidArgument.js';
 
 export function setCookie(cookie: Cookie): void {
   if (!cookie.name) {

--- a/src/client/commands/setFrame.ts
+++ b/src/client/commands/setFrame.ts
@@ -1,7 +1,7 @@
 import type { Element } from '@appium/types';
-import { InvalidArgument } from '../errors/InvalidArgument';
-import { NoSuchFrame } from '../errors/NoSuchFrame';
-import { fromWebDriverElement, toWebDriverElement, WEB_ELEMENT_IDENTIFIER } from '../helpers/Element';
+import { InvalidArgument } from '../errors/InvalidArgument.js';
+import { NoSuchFrame } from '../errors/NoSuchFrame.js';
+import { fromWebDriverElement, toWebDriverElement, WEB_ELEMENT_IDENTIFIER } from '../helpers/Element.js';
 
 export function setFrame(id: null | number | string | Element): any {
   // switch to main frame

--- a/src/client/commands/setValue.ts
+++ b/src/client/commands/setValue.ts
@@ -1,6 +1,6 @@
-import { ElementNotInteractable } from '../errors/ElementNotInteractable';
-import { fromWebDriverElement } from '../helpers/Element';
-import { ATOMIC_TYPES, isEditableElement } from '../helpers/isEditableElement';
+import { ElementNotInteractable } from '../errors/ElementNotInteractable.js';
+import { fromWebDriverElement } from '../helpers/Element.js';
+import { ATOMIC_TYPES, isEditableElement } from '../helpers/isEditableElement.js';
 
 export function setValue(text: string | string[], elementId: string): void {
   text = Array.isArray(text) ? text.join('') : text;

--- a/src/client/commands/setWindowRect.ts
+++ b/src/client/commands/setWindowRect.ts
@@ -1,6 +1,6 @@
 import type { Rect } from '@appium/types';
-import { InvalidArgument } from '../errors/InvalidArgument';
-import { getWindowRect } from './getWindowRect';
+import { InvalidArgument } from '../errors/InvalidArgument.js';
+import { getWindowRect } from './getWindowRect.js';
 
 export function setWindowRect(x?: number, y?: number, width?: number, height?: number): Rect {
   const hasX = typeof x === 'number';

--- a/src/client/errors/ElementNotInteractable.ts
+++ b/src/client/errors/ElementNotInteractable.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const ElementNotInteractable = WebDriverError.forCode('element not interactable');

--- a/src/client/errors/InvalidArgument.ts
+++ b/src/client/errors/InvalidArgument.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const InvalidArgument = WebDriverError.forCode('invalid argument');

--- a/src/client/errors/InvalidElementState.ts
+++ b/src/client/errors/InvalidElementState.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const InvalidElementState = WebDriverError.forCode('invalid element state');

--- a/src/client/errors/JavaScriptError.ts
+++ b/src/client/errors/JavaScriptError.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const JavaScriptError = WebDriverError.forCode('javascript error');

--- a/src/client/errors/NoSuchCookie.ts
+++ b/src/client/errors/NoSuchCookie.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const NoSuchCookie = WebDriverError.forCode('no such cookie');

--- a/src/client/errors/NoSuchElement.ts
+++ b/src/client/errors/NoSuchElement.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const NoSuchElement = WebDriverError.forCode('no such element');

--- a/src/client/errors/NoSuchFrame.ts
+++ b/src/client/errors/NoSuchFrame.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const NoSuchFrame = WebDriverError.forCode('no such frame');

--- a/src/client/errors/StaleElementReference.ts
+++ b/src/client/errors/StaleElementReference.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const StaleElementReference = WebDriverError.forCode('stale element reference');

--- a/src/client/errors/UnknownCommand.ts
+++ b/src/client/errors/UnknownCommand.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const UnknownCommand = WebDriverError.forCode('unknown command');

--- a/src/client/errors/UnknownError.ts
+++ b/src/client/errors/UnknownError.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const UnknownError = WebDriverError.forCode('unknown error');

--- a/src/client/errors/UnsupportedOperation.ts
+++ b/src/client/errors/UnsupportedOperation.ts
@@ -1,3 +1,3 @@
-import { WebDriverError } from './WebDriverError';
+import { WebDriverError } from './WebDriverError.js';
 
 export const UnsupportedOperation = WebDriverError.forCode('unsupported operation');

--- a/src/client/helpers/Element.ts
+++ b/src/client/helpers/Element.ts
@@ -1,6 +1,6 @@
 import type { Element as WebDriverElement } from '@appium/types';
 import { v4 as uuid } from 'uuid';
-import { StaleElementReference } from '../errors/StaleElementReference';
+import { StaleElementReference } from '../errors/StaleElementReference.js';
 
 // @ts-ignore
 const ELEMENTS: Record<string, HTMLElement> = window.APPIUM_HTML_DRIVER_ELEMENTS || (window.APPIUM_HTML_DRIVER_ELEMENTS = {});

--- a/src/client/helpers/getElement.ts
+++ b/src/client/helpers/getElement.ts
@@ -1,6 +1,6 @@
 import cssesc from 'cssesc';
-import { NoSuchElement } from '../errors/NoSuchElement';
-import { fromWebDriverElement } from './Element';
+import { NoSuchElement } from '../errors/NoSuchElement.js';
+import { fromWebDriverElement } from './Element.js';
 
 export function getElement(strategy: string, selector: string, context?: string): HTMLElement {
   const parent = context ? fromWebDriverElement(context) : document.documentElement;

--- a/src/client/helpers/getElements.ts
+++ b/src/client/helpers/getElements.ts
@@ -1,5 +1,5 @@
 import cssesc from 'cssesc';
-import { fromWebDriverElement } from './Element';
+import { fromWebDriverElement } from './Element.js';
 
 export function getElements(strategy: string, selector: string, context?: string): HTMLElement[] {
   const parent = context ? fromWebDriverElement(context) : document.documentElement;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 
 import { io } from 'socket.io-client';
-import { command } from './commands/command';
+import { command } from './commands/command.js';
 
 const id = '<appium-html-driver-handle>';
 const udid = '<appium-html-driver-udid>';

--- a/src/server/Driver.ts
+++ b/src/server/Driver.ts
@@ -1,18 +1,18 @@
 import { BaseDriver } from '@appium/base-driver';
 import type { Element, ExternalDriver } from '@appium/types';
-import { RemoteDevice } from './adapters/RemoteDevice';
-import { closeWindow } from './commands/closeWindow';
-import { createSession } from './commands/createSession';
-import { createNewWindow } from './commands/createNewWindow';
-import { getTimeouts } from './commands/getTimeouts';
-import { getWindowHandle } from './commands/getWindowHandle';
-import { getWindowHandles } from './commands/getWindowHandles';
-import { setFrame } from './commands/setFrame';
-import { setParentFrame } from './commands/setParentFrame';
-import { setWindow } from './commands/setWindow';
-import { timeouts } from './commands/timeouts';
-import { remote } from './helpers/remote';
-import { capabilitiesConstraints } from './capabilitiesConstraints';
+import { RemoteDevice } from './adapters/RemoteDevice.js';
+import { closeWindow } from './commands/closeWindow.js';
+import { createSession } from './commands/createSession.js';
+import { createNewWindow } from './commands/createNewWindow.js';
+import { getTimeouts } from './commands/getTimeouts.js';
+import { getWindowHandle } from './commands/getWindowHandle.js';
+import { getWindowHandles } from './commands/getWindowHandles.js';
+import { setFrame } from './commands/setFrame.js';
+import { setParentFrame } from './commands/setParentFrame.js';
+import { setWindow } from './commands/setWindow.js';
+import { timeouts } from './commands/timeouts.js';
+import { remote } from './helpers/remote.js';
+import { capabilitiesConstraints } from './capabilitiesConstraints.js';
 
 export class HtmlDriver
   extends BaseDriver<typeof capabilitiesConstraints>

--- a/src/server/adapters/DevToolsDevice.ts
+++ b/src/server/adapters/DevToolsDevice.ts
@@ -3,15 +3,21 @@ import CDP from 'chrome-remote-interface';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { retrying } from '../helpers/retrying';
-import { RemoteDevice } from './RemoteDevice';
+import { retrying } from '../helpers/retrying.js';
+import { RemoteDevice } from './RemoteDevice.js';
 
 export class DevToolsDevice implements RemoteDevice {
   private cdp!: CDP.Client;
   private options!: CDP.Options;
   private targetId!: string;
   private sessionId!: string;
-  private commandScript = fs.readFileSync(path.resolve(__dirname, 'commands', 'command.js'));
+  private commandScript = fs.readFileSync(
+    path.resolve(
+      new URL(import.meta.url + '/..').pathname,
+      'commands',
+      'command.js'
+    )
+  );
 
   async open(options: CDP.Options) {
     this.options = options;

--- a/src/server/adapters/InstrumentedDevice.ts
+++ b/src/server/adapters/InstrumentedDevice.ts
@@ -1,7 +1,7 @@
 import { errorFromW3CJsonCode, errors } from '@appium/base-driver';
 import type { Namespace, Server } from 'socket.io';
-import { getSocket } from '../helpers/server';
-import { RemoteDevice } from './RemoteDevice';
+import { getSocket } from '../helpers/server.js';
+import { RemoteDevice } from './RemoteDevice.js';
 
 export class InstrumentedDevice implements RemoteDevice {
   private sessionId!: string;

--- a/src/server/commands/closeWindow.ts
+++ b/src/server/commands/closeWindow.ts
@@ -1,7 +1,7 @@
 import { errors } from '@appium/base-driver';
-import type { HtmlDriver } from '../Driver';
-import { remote } from '../helpers/remote';
-import { retrying } from '../helpers/retrying';
+import type { HtmlDriver } from '../Driver.js';
+import { remote } from '../helpers/remote.js';
+import { retrying } from '../helpers/retrying.js';
 
 export async function closeWindow(this: HtmlDriver): Promise<string[]> {
   const handle = await this.getWindowHandle();

--- a/src/server/commands/createNewWindow.ts
+++ b/src/server/commands/createNewWindow.ts
@@ -1,10 +1,10 @@
 import { errors } from '@appium/base-driver';
 import type { NewWindow, NewWindowType } from '@appium/types';
 import { networkInterfaces } from 'os';
-import type { HtmlDriver } from '../Driver';
-import { InstrumentedDevice } from '../adapters/InstrumentedDevice';
-import { remote } from '../helpers/remote';
-import { retrying } from '../helpers/retrying';
+import type { HtmlDriver } from '../Driver.js';
+import { InstrumentedDevice } from '../adapters/InstrumentedDevice.js';
+import { remote } from '../helpers/remote.js';
+import { retrying } from '../helpers/retrying.js';
 
 export async function createNewWindow(this: HtmlDriver, type: NewWindowType): Promise<NewWindow> {
   const isInstrumentedDevice = this.remote instanceof InstrumentedDevice;

--- a/src/server/commands/createSession.ts
+++ b/src/server/commands/createSession.ts
@@ -5,11 +5,11 @@ import type {
   W3CDriverCaps,
 } from '@appium/types';
 import { URL } from 'url';
-import { HtmlDriver } from '../Driver';
-import { DevToolsDevice } from '../adapters/DevToolsDevice';
-import { InstrumentedDevice } from '../adapters/InstrumentedDevice';
-import { capabilitiesConstraints } from '../capabilitiesConstraints';
-import { getNamespace } from '../helpers/server';
+import { HtmlDriver } from '../Driver.js';
+import { DevToolsDevice } from '../adapters/DevToolsDevice.js';
+import { InstrumentedDevice } from '../adapters/InstrumentedDevice.js';
+import { capabilitiesConstraints } from '../capabilitiesConstraints.js';
+import { getNamespace } from '../helpers/server.js';
 
 export async function createSession(
   this: HtmlDriver,

--- a/src/server/commands/getTimeouts.ts
+++ b/src/server/commands/getTimeouts.ts
@@ -1,4 +1,4 @@
-import type { HtmlDriver } from '../Driver';
+import type { HtmlDriver } from '../Driver.js';
 
 export async function getTimeouts(this: HtmlDriver): Promise<Record<string, number>> {
   return {

--- a/src/server/commands/getWindowHandle.ts
+++ b/src/server/commands/getWindowHandle.ts
@@ -1,5 +1,5 @@
 import { errors } from '@appium/base-driver';
-import type { HtmlDriver } from '../Driver';
+import type { HtmlDriver } from '../Driver.js';
 
 export async function getWindowHandle(this: HtmlDriver): Promise<string> {
   const handle = await this.remote.getSession();

--- a/src/server/commands/getWindowHandles.ts
+++ b/src/server/commands/getWindowHandles.ts
@@ -1,4 +1,4 @@
-import type { HtmlDriver } from '../Driver';
+import type { HtmlDriver } from '../Driver.js';
 
 export async function getWindowHandles(this: HtmlDriver): Promise<string[]> {
   return this.remote.getSessions();

--- a/src/server/commands/setFrame.ts
+++ b/src/server/commands/setFrame.ts
@@ -1,6 +1,6 @@
 import type { Element } from '@appium/types';
-import type { HtmlDriver } from '../Driver';
-import { remote } from '../helpers/remote';
+import type { HtmlDriver } from '../Driver.js';
+import { remote } from '../helpers/remote.js';
 
 export async function setFrame(this: HtmlDriver, id: null | number | string | Element): Promise<void> {
   const frame = (await remote('setFrame').call(this, id as any)) as any;

--- a/src/server/commands/setParentFrame.ts
+++ b/src/server/commands/setParentFrame.ts
@@ -1,4 +1,4 @@
-import type { HtmlDriver } from '../Driver';
+import type { HtmlDriver } from '../Driver.js';
 
 export async function setParentFrame(this: HtmlDriver): Promise<void> {
   this.frames.splice(-1);

--- a/src/server/commands/setWindow.ts
+++ b/src/server/commands/setWindow.ts
@@ -1,6 +1,6 @@
 import { errors } from '@appium/base-driver';
-import type { HtmlDriver } from '../Driver';
-import { remote } from '../helpers/remote';
+import type { HtmlDriver } from '../Driver.js';
+import { remote } from '../helpers/remote.js';
 
 export async function setWindow(this: HtmlDriver, handle: string): Promise<void> {
   const handles = await this.getWindowHandles();

--- a/src/server/commands/timeouts.ts
+++ b/src/server/commands/timeouts.ts
@@ -1,5 +1,5 @@
 import { errors } from '@appium/base-driver';
-import type { HtmlDriver } from '../Driver';
+import type { HtmlDriver } from '../Driver.js';
 
 export async function timeouts(this: HtmlDriver, type?: string, ms?: number, script?: number, pageLoad?: number, implicit?: number): Promise<void> {
   if (script != null && script < 0) {

--- a/src/server/helpers/server.ts
+++ b/src/server/helpers/server.ts
@@ -8,7 +8,10 @@ import type { Namespace, Socket } from 'socket.io';
 import { Server } from 'socket.io';
 
 const servers = new WeakMap<HttpServer, Server>();
-const client = fs.readFileSync(path.resolve(__dirname, './client.js'), 'utf8');
+const client = fs.readFileSync(
+  path.resolve(new URL(import.meta.url + '/..').pathname, './client.js'),
+  'utf8'
+);
 
 export function isWindow(socket: Socket): boolean {
   return socket.handshake.query.type === 'window';

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,1 +1,1 @@
-export { HtmlDriver as Driver, HtmlDriver as default } from './Driver';
+export { HtmlDriver as Driver, HtmlDriver as default } from './Driver.js';

--- a/test/active.spec.ts
+++ b/test/active.spec.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_ID, startBrowser } from './_base';
+import { ELEMENT_ID, startBrowser } from './_base.js';
 
 describe('active', () => {
   const { driver } = startBrowser();

--- a/test/back.spec.ts
+++ b/test/back.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('back', () => {
   const { driver } = startBrowser();

--- a/test/clear.spec.ts
+++ b/test/clear.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('clear', () => {
   const { driver } = startBrowser();

--- a/test/click.spec.ts
+++ b/test/click.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('click', () => {
   const { driver } = startBrowser();

--- a/test/closeWindow.spec.ts
+++ b/test/closeWindow.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('closeWindow', () => {
   const { driver } = startBrowser();

--- a/test/createWindow.spec.ts
+++ b/test/createWindow.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('createWindow', () => {
   const { driver } = startBrowser();

--- a/test/deleteCookie.spec.ts
+++ b/test/deleteCookie.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('deleteCookie', () => {
   const { driver } = startBrowser();

--- a/test/deleteCookies.spec.ts
+++ b/test/deleteCookies.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('deleteCookies', () => {
   const { driver } = startBrowser();

--- a/test/elementDisplayed.spec.ts
+++ b/test/elementDisplayed.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('elementDisplayed', () => {
   const { driver } = startBrowser();

--- a/test/elementEnabled.spec.ts
+++ b/test/elementEnabled.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('elementEnabled', () => {
   const { driver } = startBrowser();

--- a/test/elementSelected.spec.ts
+++ b/test/elementSelected.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('elementSelected', () => {
   const { driver } = startBrowser();

--- a/test/execute.spec.ts
+++ b/test/execute.spec.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('execute', () => {
   const { driver } = startBrowser();

--- a/test/executeAsync.spec.ts
+++ b/test/executeAsync.spec.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('executeAsync', () => {
   const { driver } = startBrowser();

--- a/test/findElement.spec.ts
+++ b/test/findElement.spec.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_ID, inline, startBrowser } from './_base';
+import { ELEMENT_ID, inline, startBrowser } from './_base.js';
 
 describe('findElement', () => {
   const { driver } = startBrowser();

--- a/test/findElementFromElement.spec.ts
+++ b/test/findElementFromElement.spec.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('findElementFromElement', () => {
   const { driver } = startBrowser();

--- a/test/findElements.spec.ts
+++ b/test/findElements.spec.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_ID, inline, startBrowser } from './_base';
+import { ELEMENT_ID, inline, startBrowser } from './_base.js';
 
 describe('findElements', () => {
   const { driver } = startBrowser();

--- a/test/findElementsFromElement.spec.ts
+++ b/test/findElementsFromElement.spec.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('findElementsFromElement', () => {
   const { driver } = startBrowser();

--- a/test/forward.spec.ts
+++ b/test/forward.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('forward', () => {
   const { driver } = startBrowser();

--- a/test/getAttribute.spec.ts
+++ b/test/getAttribute.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('getAttribute', () => {
   const { driver } = startBrowser();

--- a/test/getCookie.spec.ts
+++ b/test/getCookie.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('getCookie', () => {
   const { driver } = startBrowser();

--- a/test/getCookies.spec.ts
+++ b/test/getCookies.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('getCookies', () => {
   const { driver } = startBrowser();

--- a/test/getCssProperty.spec.ts
+++ b/test/getCssProperty.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('getCssProperty', () => {
   const { driver } = startBrowser();

--- a/test/getElementRect.spec.ts
+++ b/test/getElementRect.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('getElementRect', () => {
   const { driver } = startBrowser();

--- a/test/getName.spec.ts
+++ b/test/getName.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('getName', () => {
   const { driver } = startBrowser();

--- a/test/getPageSource.spec.ts
+++ b/test/getPageSource.spec.ts
@@ -1,4 +1,4 @@
-import { inline, startBrowser } from './_base';
+import { inline, startBrowser } from './_base.js';
 
 describe('getPageSource', () => {
   const { driver } = startBrowser();

--- a/test/getProperty.spec.ts
+++ b/test/getProperty.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('getProperty', () => {
   const { driver } = startBrowser();

--- a/test/getText.spec.ts
+++ b/test/getText.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('getText', () => {
   const { driver } = startBrowser();

--- a/test/getTimeouts.spec.ts
+++ b/test/getTimeouts.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('getTimeouts', () => {
   const { driver } = startBrowser();

--- a/test/getUrl.spec.ts
+++ b/test/getUrl.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('getUrl', () => {
   const { driver } = startBrowser();

--- a/test/getWindowHandle.spec.ts
+++ b/test/getWindowHandle.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('getWindowHandle', () => {
   const { driver } = startBrowser();

--- a/test/getWindowHandles.spec.ts
+++ b/test/getWindowHandles.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('getWindowHandles', () => {
   const { driver } = startBrowser();

--- a/test/getWindowRect.spec.ts
+++ b/test/getWindowRect.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('getWindowRect', () => {
   const { driver } = startBrowser();

--- a/test/maximizeWindow.spec.ts
+++ b/test/maximizeWindow.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('maximizeWindow', () => {
   const { driver } = startBrowser();

--- a/test/refresh.spec.ts
+++ b/test/refresh.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('refresh', () => {
   const { driver } = startBrowser();

--- a/test/setCookie.spec.ts
+++ b/test/setCookie.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('setCookie', () => {
   const { driver } = startBrowser();

--- a/test/setFrame.spec.ts
+++ b/test/setFrame.spec.ts
@@ -1,4 +1,4 @@
-import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { ELEMENT_ID, inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('setFrame', () => {
   const { driver } = startBrowser();

--- a/test/setUrl.spec.ts
+++ b/test/setUrl.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('setUrl', () => {
   const { driver } = startBrowser();

--- a/test/setValue.spec.ts
+++ b/test/setValue.spec.ts
@@ -1,4 +1,4 @@
-import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base';
+import { inline, NOT_EXISTING_ELEMENT, startBrowser } from './_base.js';
 
 describe('setValue', () => {
   const { driver } = startBrowser();

--- a/test/setWindow.spec.ts
+++ b/test/setWindow.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('setWindow', () => {
   const { driver } = startBrowser();

--- a/test/setWindowRect.spec.ts
+++ b/test/setWindowRect.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('setWindowRect', () => {
   const { driver } = startBrowser({ headless: false });

--- a/test/timeouts.spec.ts
+++ b/test/timeouts.spec.ts
@@ -1,4 +1,4 @@
-import { startBrowser } from './_base';
+import { startBrowser } from './_base.js';
 
 describe('timeouts', () => {
   const { driver } = startBrowser();

--- a/test/title.spec.ts
+++ b/test/title.spec.ts
@@ -1,4 +1,4 @@
-import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base';
+import { HOME_PAGE, inline, Mode, MODE, startBrowser } from './_base.js';
 
 describe('title', () => {
   const { driver } = startBrowser();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "sourceMap": true,
-    "removeComments": true,
-    "lib": [
-      "ES2020"
-    ],
-    "target": "ES2020",
+    "lib": ["ES2023"],
+    "module": "ES2022",
+    "target": "ES2022",
+
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "Node",
+
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
Switched to ESM to make it easier to use third-party dependencies and to work on further improvements and platforms supports.