### PR TITLE
feat: treat instrumented context as top-level browsing context

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,49 +61,48 @@ appium driver install --source npm @dlenroc/appium-html-driver
 
 ## Commands
 
-| Command                                                       | Description                |
-| ------------------------------------------------------------- | -------------------------- |
-| [active](src/client/commands/active.ts)                       | Get active element         |
-| [back](src/client/commands/back.ts)                           | Back                       |
-| [clear](src/client/commands/clear.ts)                         | Element clear              |
-| [click](src/client/commands/click.ts)                         | Element click              |
-| [closeWindow](src/server/commands/closeWindow.ts)             | Close window               |
-| [createSession](src/server/commands/createSession.ts)         | New session                |
-| [createNewWindow](src/server/commands/createNewWindow.ts)     | New window                 |
-| [deleteCookie](src/client/commands/deleteCookie.ts)           | Delete cookie              |
-| [deleteCookies](src/client/commands/deleteCookies.ts)         | Delete all cookies         |
-| [elementDisplayed](src/client/commands/elementDisplayed.ts)   | Is element displayed       |
-| [elementEnabled](src/client/commands/elementEnabled.ts)       | Is element enabled         |
-| [elementSelected](src/client/commands/elementSelected.ts)     | Is element selected        |
-| [execute](src/client/commands/execute.ts)                     | Execute script             |
-| [executeAsync](src/client/commands/executeAsync.ts)           | Execute async script       |
-| [findElement](src/client/commands/findElOrEls.ts)             | Find element               |
-| [findElementFromElement](src/client/commands/findElOrEls.ts)  | Find element form element  |
-| [findElements](src/client/commands/findElOrEls.ts)            | Find elements              |
-| [findElementsFromElement](src/client/commands/findElOrEls.ts) | Find elements from element |
-| [forward](src/client/commands/forward.ts)                     | Forward                    |
-| [getAttribute](src/client/commands/getAttribute.ts)           | Get element attribute      |
-| [getCookie](src/client/commands/getCookie.ts)                 | Get named cookie           |
-| [getCookies](src/client/commands/getCookies.ts)               | Get all cookies            |
-| [getCssProperty](src/client/commands/getCssProperty.ts)       | Get element CSS value      |
-| [getElementRect](src/client/commands/getElementRect.ts)       | Get element rect           |
-| [getName](src/client/commands/getName.ts)                     | Get element tag name       |
-| [getPageSource](src/client/commands/getPageSource.ts)         | Get page source            |
-| [getProperty](src/client/commands/getProperty.ts)             | Get element property       |
-| [getText](src/client/commands/getText.ts)                     | Get element text           |
-| [getTimeouts](src/server/commands/getTimeouts.ts)             | Get timeouts               |
-| [getUrl](src/client/commands/getUrl.ts)                       | Get current URL            |
-| [getWindowHandle](src/server/commands/getWindowHandle.ts)     | Get window handle          |
-| [getWindowHandles](src/server/commands/getWindowHandles.ts)   | Get window handles         |
-| [getWindowRect](src/client/commands/getWindowRect.ts)         | Get window rect            |
-| [maximizeWindow](src/client/commands/maximizeWindow.ts)       | Maximize window            |
-| [refresh](src/client/commands/refresh.ts)                     | Refresh                    |
-| [setCookie](src/client/commands/setCookie.ts)                 | Add cookie                 |
-| [setFrame](src/client/commands/setFrame.ts)                   | Switch to frame            |
-| [setParentFrame](src/server/commands/setParentFrame.ts)       | Switch to parent frame     |
-| [setUrl](src/client/commands/setUrl.ts)                       | Navigate to URL            |
-| [setValue](src/client/commands/setValue.ts)                   | Element send keys          |
-| [setWindow](src/server/commands/setWindow.ts)                 | Switch to window           |
-| [setWindowRect](src/client/commands/setWindowRect.ts)         | Set window rect            |
-| [timeouts](src/server/commands/timeouts.ts)                   | Set timeouts               |
-| [title](src/client/commands/title.ts)                         | Get title                  |
+| Command                                                           | Description                |
+| ----------------------------------------------------------------- | -------------------------- |
+| [active](src/client/commands/active.ts)                           | Get active element         |
+| [back](src/client/commands/back.ts)                               | Back                       |
+| [clear](src/client/commands/clear.ts)                             | Element clear              |
+| [click](src/client/commands/click.ts)                             | Element click              |
+| [closeWindow](src/server/commands/closeWindow.ts)                 | Close window               |
+| [createNewWindow](src/server/commands/createNewWindow.ts)         | New window                 |
+| [deleteCookie](src/client/commands/deleteCookie.ts)               | Delete cookie              |
+| [deleteCookies](src/client/commands/deleteCookies.ts)             | Delete all cookies         |
+| [elementDisplayed](src/client/commands/elementDisplayed.ts)       | Is element displayed       |
+| [elementEnabled](src/client/commands/elementEnabled.ts)           | Is element enabled         |
+| [elementSelected](src/client/commands/elementSelected.ts)         | Is element selected        |
+| [execute](src/client/commands/execute.ts)                         | Execute script             |
+| [executeAsync](src/client/commands/executeAsync.ts)               | Execute async script       |
+| [findElement](src/client/commands/findElOrEls.ts)                 | Find element               |
+| [findElementFromElement](src/client/commands/findElOrEls.ts)      | Find element form element  |
+| [findElements](src/client/commands/findElOrEls.ts)                | Find elements              |
+| [findElementsFromElement](src/client/commands/findElOrEls.ts)     | Find elements from element |
+| [forward](src/client/commands/forward.ts)                         | Forward                    |
+| [getAttribute](src/client/commands/getAttribute.ts)               | Get element attribute      |
+| [getCookie](src/client/commands/getCookie.ts)                     | Get named cookie           |
+| [getCookies](src/client/commands/getCookies.ts)                   | Get all cookies            |
+| [getCssProperty](src/client/commands/getCssProperty.ts)           | Get element CSS value      |
+| [getElementRect](src/client/commands/getElementRect.ts)           | Get element rect           |
+| [getName](src/client/commands/getName.ts)                         | Get element tag name       |
+| [getPageSource](src/client/commands/getPageSource.ts)             | Get page source            |
+| [getProperty](src/client/commands/getProperty.ts)                 | Get element property       |
+| [getText](src/client/commands/getText.ts)                         | Get element text           |
+| [getTimeouts](src/server/commands/getTimeouts.ts)                 | Get timeouts               |
+| [getUrl](src/client/commands/getUrl.ts)                           | Get current URL            |
+| [getWindowHandle](src/server/commands/getWindowHandle.ts)         | Get window handle          |
+| [getWindowHandles](src/server/commands/getWindowHandles.ts)       | Get window handles         |
+| [getWindowRect](src/client/commands/getWindowRect.ts)             | Get window rect            |
+| [maximizeWindow](src/client/commands/maximizeWindow.ts)           | Maximize window            |
+| [refresh](src/client/commands/refresh.ts)                         | Refresh                    |
+| [setCookie](src/client/commands/setCookie.ts)                     | Add cookie                 |
+| [setFrame](src/client/commands/setFrame.ts)                       | Switch to frame            |
+| [setUrl](src/client/commands/setUrl.ts)                           | Navigate to URL            |
+| [setValue](src/client/commands/setValue.ts)                       | Element send keys          |
+| [setWindow](src/server/commands/setWindow.ts)                     | Switch to window           |
+| [setWindowRect](src/client/commands/setWindowRect.ts)             | Set window rect            |
+| [switchToParentFrame](src/client/commands/switchToParentFrame.ts) | Switch to parent frame     |
+| [timeouts](src/server/commands/timeouts.ts)                       | Set timeouts               |
+| [title](src/client/commands/title.ts)                             | Get title                  |

--- a/src/client/Driver.ts
+++ b/src/client/Driver.ts
@@ -5,14 +5,14 @@ import * as Commands from './commands.js';
 import { UnknownError } from './errors/UnknownError.js';
 
 class Driver {
-  protected windows: Window[] = [window];
-
-  get currentWindow() {
-    if (this.windows.length === 0) {
+  protected contexts: Window[] = [window];
+  protected topContext: Window = window;
+  get currentContext() {
+    if (this.contexts.length === 0) {
       throw UnknownError('No window found.');
     }
 
-    return this.windows[this.windows.length - 1];
+    return this.contexts[this.contexts.length - 1];
   }
 }
 

--- a/src/client/commands/active.ts
+++ b/src/client/commands/active.ts
@@ -4,7 +4,7 @@ import { NoSuchElement } from '../errors/NoSuchElement.js';
 import { toWebDriverElement } from '../helpers/Element.js';
 
 export function active(this: Driver): Element {
-  const element = this.currentWindow.document.activeElement;
+  const element = this.currentContext.document.activeElement;
 
   if (!element) {
     throw NoSuchElement('no active element');

--- a/src/client/commands/back.ts
+++ b/src/client/commands/back.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function back(this: Driver): void {
-  window.history.back();
+  this.topContext.history.back();
 }

--- a/src/client/commands/closeWindow.ts
+++ b/src/client/commands/closeWindow.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function closeWindow(this: Driver): void {
-  this.currentWindow.close();
+  this.topContext.close();
 }

--- a/src/client/commands/createNewWindow.ts
+++ b/src/client/commands/createNewWindow.ts
@@ -1,24 +1,17 @@
 import type { NewWindow } from '@appium/types';
-import { URL as URLShim } from 'url-shim';
 import { v4 as uuid } from 'uuid';
 import type { Driver } from '../Driver.js';
 import { InvalidArgument } from '../errors/InvalidArgument.js';
+import { getHomeUrl } from '../helpers/instrumentation.js';
 
 export function createNewWindow(this: Driver, type: string): NewWindow {
-  // @ts-expect-error - src can be undefined
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  const url = new URLShim(document.currentScript?.src ?? '', location.href);
-  const udid = url.searchParams.get('udid')?.trim()?.toLowerCase() || '<appium-html-driver-udid>';
   const handle = uuid();
-
-  const targetURL = new URLShim('./home', url);
-  targetURL.searchParams.set('udid', udid);
-  targetURL.searchParams.set('handle', handle);
+  const newPageHref = getHomeUrl(handle).href;
 
   if (type === 'tab') {
-    window.open(targetURL.href, '', 'noopener');
+    this.topContext.open(newPageHref, '', 'noopener');
   } else if (type === 'window') {
-    window.open(targetURL.href, '', 'resizable,noopener');
+    this.topContext.open(newPageHref, '', 'resizable,noopener');
   } else {
     throw InvalidArgument(`supported types are 'tab' and 'window', but got '${type}'`);
   }

--- a/src/client/commands/execute.ts
+++ b/src/client/commands/execute.ts
@@ -5,7 +5,7 @@ import { fromWebDriver, toWebDriver } from '../helpers/WebDriver.js';
 export function execute(this: Driver, script: string, args: unknown[]): unknown {
   args = args.map(fromWebDriver);
 
-  const fn = new this.currentWindow.window.Function(script) as (...args: unknown[]) => unknown;
+  const fn = new this.currentContext.window.Function(script) as (...args: unknown[]) => unknown;
 
   try {
     return toWebDriver(fn(...args));

--- a/src/client/commands/executeAsync.ts
+++ b/src/client/commands/executeAsync.ts
@@ -5,7 +5,7 @@ import { fromWebDriver, toWebDriver } from '../helpers/WebDriver.js';
 export async function executeAsync(this: Driver, script: string, args: unknown[]): Promise<unknown> {
   args = args.map(fromWebDriver);
 
-  const fn = new this.currentWindow.window.Function(script) as (...args: unknown[]) => unknown;
+  const fn = new this.currentContext.window.Function(script) as (...args: unknown[]) => unknown;
 
   try {
     return toWebDriver(await new Promise((resolve) => fn(...args, resolve)));

--- a/src/client/commands/findElOrEls.ts
+++ b/src/client/commands/findElOrEls.ts
@@ -4,8 +4,8 @@ import { toWebDriverElement, WEB_ELEMENT_IDENTIFIER } from '../helpers/Element.j
 import { getElement } from '../helpers/getElement.js';
 import { getElements } from '../helpers/getElements.js';
 
-export function findElOrEls(this: Driver, strategy: string, selector: string, mult: boolean, context: string): WebDriverElement | WebDriverElement[] {
-  context = context || toWebDriverElement(this.currentWindow.document.documentElement)[WEB_ELEMENT_IDENTIFIER];
+export function findElOrEls(this: Driver, strategy: string, selector: string, mult: boolean, context?: string): WebDriverElement | WebDriverElement[] {
+  context = context || toWebDriverElement(this.currentContext.document.documentElement)[WEB_ELEMENT_IDENTIFIER];
 
   if (mult) {
     return getElements(strategy, selector, context).map((element) => toWebDriverElement(element));

--- a/src/client/commands/forward.ts
+++ b/src/client/commands/forward.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function forward(this: Driver): void {
-  window.history.forward();
+  this.topContext.history.forward();
 }

--- a/src/client/commands/getCookies.ts
+++ b/src/client/commands/getCookies.ts
@@ -2,7 +2,7 @@ import type { Cookie } from '@appium/types';
 import type { Driver } from '../Driver';
 
 export function getCookies(this: Driver): Cookie[] {
-  return this.currentWindow.document.cookie.split('; ').map((cookie) => {
+  return this.currentContext.document.cookie.split('; ').map((cookie) => {
     const separatorIndex = cookie.indexOf('=');
     const name = cookie.slice(0, separatorIndex);
     const value = cookie.slice(separatorIndex + 1);

--- a/src/client/commands/getCssProperty.ts
+++ b/src/client/commands/getCssProperty.ts
@@ -3,6 +3,6 @@ import { fromWebDriverElement } from '../helpers/Element.js';
 
 export function getCssProperty(this: Driver, name: string, elementId: string): string {
   const element = fromWebDriverElement(elementId);
-  const style = this.currentWindow.getComputedStyle(element);
+  const style = this.currentContext.getComputedStyle(element);
   return style.getPropertyValue(name);
 }

--- a/src/client/commands/getElementRect.ts
+++ b/src/client/commands/getElementRect.ts
@@ -7,7 +7,7 @@ export function getElementRect(this: Driver, elementId: string): Rect {
   const rect = element.getBoundingClientRect();
   const width = Math.floor(rect.right - rect.left);
   const height = Math.floor(rect.bottom - rect.top);
-  const x = Math.floor(this.currentWindow.scrollX + rect.left);
-  const y = Math.floor(this.currentWindow.scrollY + rect.top);
+  const x = Math.floor(this.currentContext.scrollX + rect.left);
+  const y = Math.floor(this.currentContext.scrollY + rect.top);
   return { x, y, width, height };
 }

--- a/src/client/commands/getPageSource.ts
+++ b/src/client/commands/getPageSource.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function getPageSource(this: Driver): string {
-  return this.currentWindow.document.documentElement.outerHTML;
+  return this.currentContext.document.documentElement.outerHTML;
 }

--- a/src/client/commands/getUrl.ts
+++ b/src/client/commands/getUrl.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function getUrl(this: Driver): string {
-  return window.location.href;
+  return this.topContext.location.href;
 }

--- a/src/client/commands/getWindowRect.ts
+++ b/src/client/commands/getWindowRect.ts
@@ -3,9 +3,9 @@ import type { Driver } from '../Driver';
 
 export function getWindowRect(this: Driver): Rect {
   return {
-    x: window.screenX,
-    y: window.screenY,
-    width: window.outerWidth,
-    height: window.outerHeight,
+    x: this.topContext.screenX,
+    y: this.topContext.screenY,
+    width: this.topContext.outerWidth,
+    height: this.topContext.outerHeight,
   };
 }

--- a/src/client/commands/maximizeWindow.ts
+++ b/src/client/commands/maximizeWindow.ts
@@ -2,7 +2,7 @@ import type { Rect } from '@appium/types';
 import type { Driver } from '../Driver.js';
 
 export function maximizeWindow(this: Driver): Rect {
-  const width = window.screen.availWidth;
-  const height = window.screen.availHeight;
+  const width = this.topContext.screen.availWidth;
+  const height = this.topContext.screen.availHeight;
   return this.setWindowRect(0, 0, width, height);
 }

--- a/src/client/commands/refresh.ts
+++ b/src/client/commands/refresh.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function refresh(this: Driver): void {
-  window.location.reload();
+  this.topContext.location.reload();
 }

--- a/src/client/commands/setCookie.ts
+++ b/src/client/commands/setCookie.ts
@@ -33,5 +33,5 @@ export function setCookie(this: Driver, cookie: Cookie): void {
     newCookie += '; SameSite=' + cookie.sameSite;
   }
 
-  this.currentWindow.document.cookie = newCookie;
+  this.currentContext.document.cookie = newCookie;
 }

--- a/src/client/commands/setFrame.ts
+++ b/src/client/commands/setFrame.ts
@@ -7,7 +7,7 @@ import { fromWebDriverElement, WEB_ELEMENT_IDENTIFIER } from '../helpers/Element
 export function setFrame(this: Driver, id: null | number | string | Element): void {
   // switch to main frame
   if (id === null) {
-    this.windows = [window];
+    this.contexts = [window];
     return;
   }
 
@@ -17,21 +17,21 @@ export function setFrame(this: Driver, id: null | number | string | Element): vo
       throw InvalidArgument(`index must be a non-negative integer`);
     }
 
-    const frames = this.currentWindow.frames;
+    const frames = this.currentContext.frames;
     if (id >= frames.length) {
       throw NoSuchFrame(`frame with index ${id} does not exist`);
     }
 
-    this.windows.push(frames[id]);
+    this.contexts.push(frames[id]);
     return;
   }
 
   // switch to frame by name
   if (typeof id === 'string') {
-    const frames = this.currentWindow.frames;
+    const frames = this.currentContext.frames;
     for (let i = 0; i < frames.length; i++) {
       if (frames[i]?.name === id) {
-        this.windows.push(frames[i]);
+        this.contexts.push(frames[i]);
         return;
       }
     }
@@ -46,7 +46,7 @@ export function setFrame(this: Driver, id: null | number | string | Element): vo
       throw NoSuchFrame(`element is not a frame`);
     }
 
-    this.windows.push(element.contentWindow!);
+    this.contexts.push(element.contentWindow!);
     return;
   }
 

--- a/src/client/commands/setUrl.ts
+++ b/src/client/commands/setUrl.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function setUrl(this: Driver, url: string): void {
-  window.location.href = url;
+  this.topContext.location.href = url;
 }

--- a/src/client/commands/setValue.ts
+++ b/src/client/commands/setValue.ts
@@ -7,14 +7,14 @@ export function setValue(this: Driver, text: string | string[], elementId: strin
   text = Array.isArray(text) ? text.join('') : text;
 
   const element = fromWebDriverElement(elementId);
-  const isFocused = this.currentWindow.document.activeElement === element;
+  const isFocused = this.currentContext.document.activeElement === element;
 
   if (!isEditableElement(element)) {
     throw ElementNotInteractable('element is not editable');
   }
 
   if (element.isContentEditable) {
-    const selection = this.currentWindow.getSelection();
+    const selection = this.currentContext.getSelection();
 
     if (!isFocused) {
       element.focus();
@@ -23,7 +23,7 @@ export function setValue(this: Driver, text: string | string[], elementId: strin
     }
 
     if (selection?.rangeCount) {
-      const node = this.currentWindow.document.createTextNode(text);
+      const node = this.currentContext.document.createTextNode(text);
       const range = selection.getRangeAt(0);
       range.deleteContents();
       range.insertNode(node);

--- a/src/client/commands/setWindow.ts
+++ b/src/client/commands/setWindow.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function setWindow(this: Driver): void {
-  window.focus();
+  this.topContext.focus();
 }

--- a/src/client/commands/setWindowRect.ts
+++ b/src/client/commands/setWindowRect.ts
@@ -18,11 +18,11 @@ export function setWindowRect(this: Driver, x?: number, y?: number, width?: numb
 
   for (let i = 0; i < 3; i++) {
     if (hasX && hasY) {
-      window.moveTo(x, y);
+      this.topContext.moveTo(x, y);
     }
 
     if (hasWidth && hasHeight) {
-      window.resizeTo(width, height);
+      this.topContext.resizeTo(width, height);
     }
   }
 

--- a/src/client/commands/switchToParentFrame.ts
+++ b/src/client/commands/switchToParentFrame.ts
@@ -1,7 +1,7 @@
 import type { Driver } from '../Driver';
 
 export function switchToParentFrame(this: Driver): void {
-  if (this.windows.length > 1) {
-    this.windows.pop();
+  if (this.contexts.length > 1) {
+    this.contexts.pop();
   }
 }

--- a/src/client/commands/title.ts
+++ b/src/client/commands/title.ts
@@ -1,5 +1,5 @@
 import type { Driver } from '../Driver';
 
 export function title(this: Driver): string {
-  return window.document.title;
+  return this.topContext.document.title;
 }

--- a/src/client/helpers/instrumentation.ts
+++ b/src/client/helpers/instrumentation.ts
@@ -1,0 +1,14 @@
+import { URL as URLShim } from 'url-shim';
+
+// @ts-expect-error - src can be undefined
+// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+export const currentURL = new URLShim(document.currentScript?.src ?? '', location.href);
+export const currentUDID = currentURL.searchParams.get('udid')?.trim() || '<appium-html-driver-udid>';
+export const currentHandle = currentURL.searchParams.get('handle')?.trim() || '<appium-html-driver-handle>';
+
+export function getHomeUrl(handle: string): URLShim {
+  const url = new URLShim('./home', currentURL);
+  url.searchParams.set('udid', currentUDID);
+  url.searchParams.set('handle', handle);
+  return url;
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,18 +4,11 @@ import { io } from 'socket.io-client';
 import { URL as URLShim } from 'url-shim';
 import { Driver } from './Driver.js';
 import { UnsupportedOperation } from './errors/UnsupportedOperation.js';
+import { currentHandle, currentUDID, currentURL } from './helpers/instrumentation.js';
 
 const driver = new Driver();
 
-// @ts-expect-error - src can be undefined
-// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-const url = new URLShim(document.currentScript?.src ?? '', location.href);
-const path = new URLShim('./ws', url).pathname;
-const udid = url.searchParams.get('udid')?.trim() || '<appium-html-driver-udid>';
-const handle = url.searchParams.get('handle')?.trim() || '<appium-html-driver-handle>';
-const type = window.top === window ? 'window' : 'frame';
-
-io(url.origin + '/' + udid, { path, query: { handle, type } }).on('command', async ({ command, args }: { command: string; args: unknown[] }, callback: (data?: [error: unknown, data: unknown]) => void) => {
+io(currentURL.origin + '/' + currentUDID, { path: new URLShim('./ws', currentURL).pathname, query: { handle: currentHandle } }).on('command', async ({ command, args }: { command: string; args: unknown[] }, callback: (data?: [error: unknown, data: unknown]) => void) => {
   try {
     if (command in driver && typeof driver[command as keyof typeof driver] === 'function') {
       const result = await (driver[command as keyof typeof driver] as (...args: unknown[]) => unknown)(...args);

--- a/src/server/Driver.ts
+++ b/src/server/Driver.ts
@@ -23,7 +23,7 @@ import { timeouts } from './commands/timeouts.js';
 import { remote } from './helpers/remote.js';
 
 export class HtmlDriver extends BaseDriver<typeof capabilitiesConstraints> implements ExternalDriver<typeof capabilitiesConstraints> {
-  private static IO: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, { handle: string; type: string }>;
+  private static IO: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, { handle: string }>;
 
   static async updateServer(app: Application, server: HttpServer) {
     const log = logger.getLogger('HtmlDriver-Server');
@@ -49,7 +49,7 @@ export class HtmlDriver extends BaseDriver<typeof capabilitiesConstraints> imple
         res.end(client.replaceAll('<appium-html-driver-udid>', udid).replaceAll('<appium-html-driver-handle>', handle));
       });
 
-    HtmlDriver.IO = new Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, { handle: string; type: string }>(server, {
+    HtmlDriver.IO = new Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, { handle: string }>(server, {
       path: '/appium-html-driver/ws',
       serveClient: false,
       cors: { origin: '*' },
@@ -63,7 +63,6 @@ export class HtmlDriver extends BaseDriver<typeof capabilitiesConstraints> imple
 
       if (!socket.recovered) {
         socket.data.handle = typeof socket.handshake.query.handle === 'string' ? socket.handshake.query.handle.trim() : randomUUID();
-        socket.data.type = typeof socket.handshake.query.type === 'string' ? socket.handshake.query.type.trim() : 'window';
       }
 
       log.info('Socket "%s" (%s) connected to "%s"', socket.data.handle, socket.id, udid);
@@ -98,12 +97,12 @@ export class HtmlDriver extends BaseDriver<typeof capabilitiesConstraints> imple
   // WebDriver Commands
   public getTimeouts = getTimeouts;
   public timeouts = timeouts;
-  public setUrl = remote('setUrl', { requireWindow: true, noWait: true });
-  public getUrl = remote('getUrl', { requireWindow: true });
-  public back = remote('back', { requireWindow: true, noWait: true });
-  public forward = remote('forward', { requireWindow: true, noWait: true });
-  public refresh = remote('refresh', { requireWindow: true, noWait: true });
-  public title = remote('title', { requireWindow: true });
+  public setUrl = remote('setUrl');
+  public getUrl = remote('getUrl');
+  public back = remote('back');
+  public forward = remote('forward');
+  public refresh = remote('refresh');
+  public title = remote('title');
   public getWindowHandle = getWindowHandle;
   public closeWindow = closeWindow;
   public createNewWindow = createNewWindow;
@@ -111,10 +110,11 @@ export class HtmlDriver extends BaseDriver<typeof capabilitiesConstraints> imple
   public getWindowHandles = getWindowHandles;
   public setFrame = remote('setFrame');
   public switchToParentFrame = remote('switchToParentFrame');
-  public getWindowRect = remote('getWindowRect', { requireWindow: true });
-  public setWindowRect = remote('setWindowRect', { requireWindow: true });
-  public maximizeWindow = remote('maximizeWindow', { requireWindow: true });
+  public getWindowRect = remote('getWindowRect');
+  public setWindowRect = remote('setWindowRect');
+  public maximizeWindow = remote('maximizeWindow');
   public active = remote('active');
+  // @ts-expect-error - improve typing
   public findElOrEls = remote('findElOrEls');
   public elementSelected = remote('elementSelected');
   public getAttribute = remote('getAttribute');

--- a/src/server/commands/closeWindow.ts
+++ b/src/server/commands/closeWindow.ts
@@ -1,12 +1,11 @@
 import { errors } from '@appium/base-driver';
 import type { HtmlDriver } from '../Driver.js';
-import { remote } from '../helpers/remote.js';
 import { retrying } from '../helpers/retrying.js';
 
 export async function closeWindow(this: HtmlDriver): Promise<string[]> {
   const handle = await this.getWindowHandle();
 
-  await remote('closeWindow', { requireWindow: true, noWait: true }).call(this);
+  await this.executeRemoteCommand('closeWindow');
 
   return retrying({
     timeout: this.socketTimeoutMs,

--- a/src/server/commands/createNewWindow.ts
+++ b/src/server/commands/createNewWindow.ts
@@ -1,11 +1,10 @@
 import { errors } from '@appium/base-driver';
 import type { NewWindow, NewWindowType } from '@appium/types';
 import type { HtmlDriver } from '../Driver.js';
-import { remote } from '../helpers/remote.js';
 import { retrying } from '../helpers/retrying.js';
 
 export async function createNewWindow(this: HtmlDriver, type: NewWindowType): Promise<NewWindow> {
-  const window = await remote('createNewWindow', { requireWindow: true }).call(this, type);
+  const window = await this.executeRemoteCommand('createNewWindow', type);
 
   await retrying({
     timeout: this.socketTimeoutMs,

--- a/src/server/commands/execute.ts
+++ b/src/server/commands/execute.ts
@@ -1,7 +1,6 @@
 import type { HtmlDriver } from '../Driver';
 import { compile } from '../helpers/compile';
-import { remote } from '../helpers/remote';
 
 export async function execute(this: HtmlDriver, script: string, args: unknown[]): Promise<unknown> {
-  return remote('execute').call(this, await compile(script), args);
+  return this.executeRemoteCommand('execute', await compile(script), args);
 }

--- a/src/server/commands/executeAsync.ts
+++ b/src/server/commands/executeAsync.ts
@@ -1,7 +1,6 @@
 import type { HtmlDriver } from '../Driver';
 import { compile } from '../helpers/compile';
-import { remote } from '../helpers/remote';
 
 export async function executeAsync(this: HtmlDriver, script: string, args: unknown[]): Promise<unknown> {
-  return remote('executeAsync').call(this, await compile(script), args);
+  return this.executeRemoteCommand('executeAsync', await compile(script), args);
 }

--- a/src/server/commands/internal/executeRemoteCommand.ts
+++ b/src/server/commands/internal/executeRemoteCommand.ts
@@ -3,7 +3,7 @@ import type { Driver as ClientDriver } from '../../../client/Driver';
 import type { HtmlDriver } from '../../Driver';
 
 type Commands = {
-  [K in keyof ClientDriver as ClientDriver[K] extends (...args: unknown[]) => unknown ? K : never]: ClientDriver[K];
+  [K in keyof ClientDriver as ClientDriver[K] extends (...args: never[]) => unknown ? K : never]: ClientDriver[K];
 };
 
 export function executeRemoteCommand<T extends keyof Commands>(this: HtmlDriver, command: T, ...args: Parameters<Commands[T]>): Promise<Awaited<ReturnType<Commands[T]>>> {

--- a/src/server/commands/setWindow.ts
+++ b/src/server/commands/setWindow.ts
@@ -1,6 +1,5 @@
 import { errors } from '@appium/base-driver';
 import type { HtmlDriver } from '../Driver.js';
-import { remote } from '../helpers/remote.js';
 
 export async function setWindow(this: HtmlDriver, handle: string): Promise<void> {
   const handles = await this.getWindowHandles();
@@ -10,5 +9,5 @@ export async function setWindow(this: HtmlDriver, handle: string): Promise<void>
 
   this.opts.handle = handle;
 
-  await remote('setWindow').call(this, handle);
+  await this.executeRemoteCommand('setWindow');
 }

--- a/test/back.spec.ts
+++ b/test/back.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { HOME_PAGE, startBrowser } from './_base.js';
 
 describe('back', () => {
   const { driver } = startBrowser();
@@ -12,16 +12,5 @@ describe('back', () => {
 
     await driver.getUrl()
       .should.eventually.be.equal(`${HOME_PAGE}&handle=main#page1`);
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.back()
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/createWindow.spec.ts
+++ b/test/createWindow.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { startBrowser } from './_base.js';
 
 describe('createWindow', () => {
   const { driver } = startBrowser();
@@ -29,16 +29,5 @@ describe('createWindow', () => {
   it('should throw InvalidArgument', async () => {
     await driver.createWindow('invalid' as any)
       .should.eventually.be.rejected.with.property('name', 'invalid argument');
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.createWindow('window')
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/forward.spec.ts
+++ b/test/forward.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { HOME_PAGE, startBrowser } from './_base.js';
 
 describe('forward', () => {
   const { driver } = startBrowser();
@@ -13,16 +13,5 @@ describe('forward', () => {
 
     await driver.getUrl()
       .should.eventually.be.equal(`${HOME_PAGE}&handle=main#page2`);
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.forward()
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/getUrl.spec.ts
+++ b/test/getUrl.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { HOME_PAGE, startBrowser } from './_base.js';
 
 describe('getUrl', () => {
   const { driver } = startBrowser();
@@ -9,16 +9,5 @@ describe('getUrl', () => {
 
     await driver.getUrl()
       .should.eventually.be.equal(`${HOME_PAGE}&handle=main#page`);
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.getUrl()
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/getWindowRect.spec.ts
+++ b/test/getWindowRect.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { startBrowser } from './_base.js';
 
 describe('getWindowRect', () => {
   const { driver } = startBrowser();
@@ -16,16 +16,5 @@ describe('getWindowRect', () => {
 
     await driver.getWindowRect()
       .should.eventually.be.eql(rect);
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.getWindowRect()
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/maximizeWindow.spec.ts
+++ b/test/maximizeWindow.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { startBrowser } from './_base.js';
 
 describe('maximizeWindow', () => {
   const { driver } = startBrowser();
@@ -16,16 +16,5 @@ describe('maximizeWindow', () => {
 
     await driver.maximizeWindow()
       .should.eventually.be.eql(rect);
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.maximizeWindow()
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/refresh.spec.ts
+++ b/test/refresh.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { startBrowser } from './_base.js';
 
 describe('refresh', () => {
   const { driver } = startBrowser();
@@ -15,16 +15,5 @@ describe('refresh', () => {
 
     await driver.executeScript('return window.noReloaded || location.href', [])
       .should.eventually.be.equal(url);
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.navigateTo(`${HOME_PAGE}&handle=main#other_page`)
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/setUrl.spec.ts
+++ b/test/setUrl.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { HOME_PAGE, startBrowser } from './_base.js';
 
 describe('setUrl', () => {
   const { driver } = startBrowser();
@@ -9,16 +9,5 @@ describe('setUrl', () => {
 
     await driver.getUrl()
       .should.eventually.be.equal(`${HOME_PAGE}&handle=main#other_page`);
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.navigateTo(HOME_PAGE)
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/setWindowRect.spec.ts
+++ b/test/setWindowRect.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { startBrowser } from './_base.js';
 
 describe('setWindowRect', () => {
   const { driver } = startBrowser({ headless: false });
@@ -28,16 +28,5 @@ describe('setWindowRect', () => {
   it('should throw InvalidArgument', async () => {
     await driver.setWindowRect(-1, -1, -1, -1)
       .should.eventually.be.rejected.with.property('name', 'invalid argument');
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.setWindowRect(rect.x, rect.y, rect.width, rect.height)
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });

--- a/test/title.spec.ts
+++ b/test/title.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test';
-import { HOME_PAGE, inline, startBrowser } from './_base.js';
+import { inline, startBrowser } from './_base.js';
 
 describe('title', () => {
   const { driver } = startBrowser();
@@ -11,16 +11,5 @@ describe('title', () => {
 
     await driver.getTitle()
       .should.eventually.be.equal('Page title');
-  });
-
-  it('should throw UnsupportedOperation for instrumented frame', async () => {
-    await inline(`
-      <iframe src="${HOME_PAGE}&handle=frame"/>
-    `);
-
-    await driver.switchToWindow('frame');
-
-    await driver.getTitle()
-      .should.eventually.be.rejected.with.property('name', 'unsupported operation');
   });
 });


### PR DESCRIPTION
Updated commands to use the instrumented context as the top-level browsing context. This ensures that commands intended to run on a window can now execute within instrumented iframes without throwing an `UnsupportedOperation` exception.
