### PR TITLE
feat: on-screen display for connection status

### DIFF
--- a/src/client/OSD.ts
+++ b/src/client/OSD.ts
@@ -1,0 +1,84 @@
+import { INSTRUMENTATION_HANDLE, INSTRUMENTATION_UDID } from './helpers/instrumentation';
+
+// Create the iframe to isolate styles
+const iframe = document.createElement('iframe');
+iframe.style.position = 'fixed';
+iframe.style.top = '5%';
+iframe.style.right = '5%';
+iframe.style.zIndex = '9999';
+iframe.style.pointerEvents = 'none';
+iframe.style.border = 'none';
+iframe.style.width = '300px';
+iframe.style.height = 'auto';
+
+// Append the iframe to the body
+document.documentElement.appendChild(iframe);
+
+// Access the iframe's document
+const iframeDoc = iframe.contentDocument || iframe.contentWindow!.document;
+iframeDoc.open();
+iframeDoc.close();
+
+// Reset iframe's styles for isolation
+iframeDoc.body.style.margin = '0';
+iframeDoc.body.style.padding = '0';
+iframeDoc.body.style.backgroundColor = 'transparent';
+iframeDoc.body.style.overflow = 'hidden';
+
+// Apply global styles for consistent text appearance
+iframeDoc.body.style.fontFamily = 'Arial, sans-serif';
+iframeDoc.body.style.fontSize = '0.9rem';
+iframeDoc.body.style.textAlign = 'center';
+iframeDoc.body.style.color = '#fff';
+iframeDoc.body.style.wordBreak = 'break-all';
+
+// Create the panel element inside the iframe
+const panel = iframeDoc.createElement('div');
+panel.style.backgroundColor = 'rgba(30, 30, 30, 0.9)';
+panel.style.border = '1px solid #333';
+panel.style.borderRadius = '5px';
+panel.style.boxShadow = '0 4px 8px rgba(0, 0, 0, 0.3)';
+
+// Create the header
+const header = iframeDoc.createElement('div');
+header.textContent = '@dlenroc/appium-html-driver';
+header.style.backgroundColor = '#212121';
+header.style.padding = '8px 12px';
+header.style.fontWeight = 'bold';
+header.style.borderBottom = '1px solid #333';
+
+// Create the content area
+const content = iframeDoc.createElement('div');
+content.style.padding = '10px';
+
+// Add content elements
+const udidElement = iframeDoc.createElement('p');
+udidElement.textContent = INSTRUMENTATION_UDID;
+udidElement.style.margin = '4px 0';
+udidElement.style.color = '#9ccc65';
+
+const handleElement = iframeDoc.createElement('p');
+handleElement.textContent = INSTRUMENTATION_HANDLE;
+handleElement.style.margin = '4px 0';
+handleElement.style.color = '#29b6f6';
+
+const statusElement = iframeDoc.createElement('p');
+statusElement.textContent = 'Connecting...';
+statusElement.style.color = '#ff9800';
+statusElement.style.margin = '4px 0';
+
+// Append elements to the content area
+content.appendChild(udidElement);
+content.appendChild(handleElement);
+content.appendChild(statusElement);
+
+// Assemble the panel
+panel.appendChild(header);
+panel.appendChild(content);
+
+// Append panel to iframe's body
+iframeDoc.body.appendChild(panel);
+
+export function updateStatusText(status: string) {
+  statusElement.textContent = status;
+}

--- a/src/client/helpers/instrumentation.ts
+++ b/src/client/helpers/instrumentation.ts
@@ -2,13 +2,13 @@ import { URL as URLShim } from 'url-shim';
 
 // @ts-expect-error - src can be undefined
 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-export const currentURL = new URLShim(document.currentScript?.src ?? '', location.href);
-export const currentUDID = currentURL.searchParams.get('udid')?.trim() || '<appium-html-driver-udid>';
-export const currentHandle = currentURL.searchParams.get('handle')?.trim() || '<appium-html-driver-handle>';
+export const INSTRUMENTATION_URL = new URLShim(document.currentScript?.src ?? '', location.href);
+export const INSTRUMENTATION_UDID = INSTRUMENTATION_URL.searchParams.get('udid')?.trim() || '<appium-html-driver-udid>';
+export const INSTRUMENTATION_HANDLE = INSTRUMENTATION_URL.searchParams.get('handle')?.trim() || '<appium-html-driver-handle>';
 
 export function getHomeUrl(handle: string): URLShim {
-  const url = new URLShim('./home', currentURL);
-  url.searchParams.set('udid', currentUDID);
+  const url = new URLShim('./home', INSTRUMENTATION_URL);
+  url.searchParams.set('udid', INSTRUMENTATION_UDID);
   url.searchParams.set('handle', handle);
   return url;
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,22 +4,27 @@ import { io } from 'socket.io-client';
 import { URL as URLShim } from 'url-shim';
 import { Driver } from './Driver.js';
 import { UnsupportedOperation } from './errors/UnsupportedOperation.js';
-import { currentHandle, currentUDID, currentURL } from './helpers/instrumentation.js';
+import { INSTRUMENTATION_HANDLE, INSTRUMENTATION_UDID, INSTRUMENTATION_URL } from './helpers/instrumentation.js';
+import * as osd from './OSD.js';
 
 const driver = new Driver();
 
-io(currentURL.origin + '/' + currentUDID, { path: new URLShim('./ws', currentURL).pathname, query: { handle: currentHandle } }).on('command', async ({ command, args }: { command: string; args: unknown[] }, callback: (data?: [error: unknown, data: unknown]) => void) => {
-  try {
-    if (command in driver && typeof driver[command as keyof typeof driver] === 'function') {
-      const result = await (driver[command as keyof typeof driver] as (...args: unknown[]) => unknown)(...args);
-      callback([null, result]);
-      return;
+io(INSTRUMENTATION_URL.origin + '/' + INSTRUMENTATION_UDID, { path: new URLShim('./ws', INSTRUMENTATION_URL).pathname, query: { handle: INSTRUMENTATION_HANDLE } })
+  .on('connect', () => osd.updateStatusText('connected'))
+  .on('connect_error', (error) => osd.updateStatusText(`connection error: ${error.message}`))
+  .on('disconnect', (reason) => osd.updateStatusText(`disconnected due to ${reason}`))
+  .on('command', async ({ command, args }: { command: string; args: unknown[] }, callback: (data?: [error: unknown, data: unknown]) => void) => {
+    try {
+      if (command in driver && typeof driver[command as keyof typeof driver] === 'function') {
+        const result = await (driver[command as keyof typeof driver] as (...args: unknown[]) => unknown)(...args);
+        callback([null, result]);
+        return;
+      }
+
+      throw UnsupportedOperation(`Unsupported command: ${command}`);
+    } catch (cause) {
+      const error = cause instanceof Error ? cause : Error(JSON.stringify(cause));
+
+      callback([{ name: error.name, message: error.message, stack: error.stack }, null]);
     }
-
-    throw UnsupportedOperation(`Unsupported command: ${command}`);
-  } catch (cause) {
-    const error = cause instanceof Error ? cause : Error(JSON.stringify(cause));
-
-    callback([{ name: error.name, message: error.message, stack: error.stack }, null]);
-  }
-});
+  });

--- a/src/server/Driver.ts
+++ b/src/server/Driver.ts
@@ -45,7 +45,9 @@ export class HtmlDriver extends BaseDriver<typeof capabilitiesConstraints> imple
       .get('/appium-html-driver/js', (req, res) => {
         const { handle, udid } = getParams(req);
         res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
         res.setHeader('Content-Type', 'text/javascript');
+        res.setHeader('Expires', '0');
         res.end(client.replaceAll('<appium-html-driver-udid>', udid).replaceAll('<appium-html-driver-handle>', handle));
       });
 


### PR DESCRIPTION
Added a small OSD panel in the upper-right corner to display the UDID, handle, and connection status, assisting with device identification and troubleshooting connection-related issues.

<p align="center">
  <img width="305" alt="Screenshot 2024-11-18 at 22 10 13" src="https://github.com/user-attachments/assets/1358a58f-271b-4cf4-b07d-30207abfa953">
</p>

> 🚨 it is not pointer-interactive. However, if it is found to affect tests, an option to hide it will be added.